### PR TITLE
fix: use signers instead of operators for validate signature checks

### DIFF
--- a/contracts/src/ecdsa/interfaces/IPOAStakeRegistry.sol
+++ b/contracts/src/ecdsa/interfaces/IPOAStakeRegistry.sol
@@ -32,6 +32,8 @@ interface IPOAStakeRegistryErrors {
     error InvalidQuorum();
     /// @notice Thrown when the weight is invalid.
     error InvalidWeight();
+    /// @notice Thrown when the signer is not registered.
+    error SignerNotRegistered();
 }
 
 /**


### PR DESCRIPTION
## Summary

The previous instance that was ported over was incorrect & resulted in `ServiceManagerValidateKnown(InvalidSignature(InvalidSignature))
`, moved to this and the PoA contract now works in EN0VA as I originally had it in the old PoA contract.

<img width="1685" height="389" alt="image" src="https://github.com/user-attachments/assets/7105dec7-b631-4e50-84b4-5db9bea2ff42" />
